### PR TITLE
Updog Day At Home

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         exclude: "tests/fixture/no_newline_file.txt"
     -   id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.6
+    rev: v19.1.7
     hooks:
       - id: clang-format
         exclude: ".json"
@@ -38,15 +38,15 @@ repos:
     hooks:
     - id: add-trailing-comma
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     - id: mypy
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.6
+    rev: v1.7.7
     hooks:
     - id: actionlint
   - repo: https://github.com/sco1/brie-commit


### PR DESCRIPTION
We have autoupdate day at home! 

Update day at home:

```console
 ~/workspace/iris (main|u=) -> pre-commit autoupdate
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/pre-commit/mirrors-clang-format] updating v19.1.6 -> v19.1.7
[https://github.com/cmake-lint/cmake-lint] already up to date!
[https://github.com/asottile/reorder-python-imports] already up to date!
[https://github.com/asottile/add-trailing-comma] already up to date!
[https://github.com/PyCQA/flake8] updating 7.1.1 -> 7.1.2
[https://github.com/pre-commit/mirrors-mypy] updating v1.14.1 -> v1.15.0
[https://github.com/rhysd/actionlint] updating v1.7.6 -> v1.7.7
[https://github.com/sco1/brie-commit] already up to date!
```